### PR TITLE
Create-controller

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,0 +1,26 @@
+import { InternalServerError, MethodNotAllowedError } from "./errors";
+
+function onNoMatchHandler(request, response) {
+  const publicError = new MethodNotAllowedError();
+
+  response.status(publicError.statusCode).json(publicError);
+}
+
+function onErrorHandler(error, request, response) {
+  const publicError = new InternalServerError({
+    cause: error,
+    statusCode: error.statusCode,
+  });
+
+  console.log(publicError);
+  response.status(publicError.statusCode).json(publicError);
+}
+
+const controller = {
+  options: {
+    onNoMatch: onNoMatchHandler,
+    onError: onErrorHandler,
+  },
+};
+
+export default controller;

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,4 +1,5 @@
 import { Client } from "pg";
+import { ServiceError } from "./errors";
 
 export async function getNewClient() {
   const client = new Client({
@@ -22,8 +23,11 @@ export async function query(queryObject, queryValues) {
 
     return result;
   } catch (error) {
-    console.error(error);
-    throw error;
+    const serviceError = new ServiceError({
+      message: "Erro no conexão com o Banco de Dados ou na Query.",
+      cause: error,
+    });
+    throw serviceError;
   } finally {
     await client?.end();
   }

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -19,3 +19,22 @@ export class InternalServerError extends Error {
     };
   }
 }
+
+export class MethodNotAllowedError extends Error {
+  name = "MethodNotAllowedError";
+  action = "Verifique se o método HTTP enviado é válido para este endpoint.";
+  statusCode = 405;
+
+  constructor() {
+    super("Método não permitido para este endpoint.");
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -1,10 +1,9 @@
 export class InternalServerError extends Error {
-  name = "InternalServerError";
-  action = "Entre em contato com o suporte.";
-  statusCode = 500;
-
-  constructor({ cause }) {
+  constructor({ cause, statusCode }) {
     super("Um erro interno não esperado aconteceu.", { cause });
+    this.name = "InternalServerError";
+    this.action = "Entre em contato com o suporte.";
+    this.statusCode = statusCode || 500;
   }
 
   // .json() method use a JSON.stringify() to transform this object.
@@ -20,13 +19,31 @@ export class InternalServerError extends Error {
   }
 }
 
-export class MethodNotAllowedError extends Error {
-  name = "MethodNotAllowedError";
-  action = "Verifique se o método HTTP enviado é válido para este endpoint.";
-  statusCode = 405;
+export class ServiceError extends Error {
+  constructor({ cause, message }) {
+    super(message || "Serviço indisponível no momento.", { cause });
+    this.name = "ServiceError";
+    this.action = "Verifique se o serviço está disponível.";
+    this.statusCode = 503;
+  }
 
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class MethodNotAllowedError extends Error {
   constructor() {
     super("Método não permitido para este endpoint.");
+    this.name = "MethodNotAllowedError";
+    this.action =
+      "Verifique se o método HTTP enviado é válido para este endpoint.";
+    this.statusCode = 405;
   }
 
   toJSON() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "16.4.5",
         "dotenv-expand": "11.0.6",
         "next": "14.2.5",
+        "next-connect": "1.0.0",
         "node-pg-migrate": "7.6.1",
         "pg": "8.12.0",
         "react": "18.3.1",
@@ -2071,6 +2072,12 @@
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -8755,6 +8762,19 @@
         }
       }
     },
+    "node_modules/next-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-1.0.0.tgz",
+      "integrity": "sha512-FeLURm9MdvzY1SDUGE74tk66mukSqL6MAzxajW7Gqh6DZKBZLrXmXnGWtHJZXkfvoi+V/DUe9Hhtfkl4+nTlYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsconfig/node16": "^1.0.3",
+        "regexparam": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -9868,6 +9888,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexparam": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-2.0.2.tgz",
+      "integrity": "sha512-A1PeDEYMrkLrfyOwv2jwihXbo9qxdGD3atBYQA9JJgreAx8/7rC6IUkWOw2NQlOxLp2wL0ifQbh1HuidDfYA6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dotenv": "16.4.5",
     "dotenv-expand": "11.0.6",
     "next": "14.2.5",
+    "next-connect": "1.0.0",
     "node-pg-migrate": "7.6.1",
     "pg": "8.12.0",
     "react": "18.3.1",

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,40 +1,54 @@
+import { createRouter } from "next-connect";
 import { query } from "infra/database";
-import { InternalServerError } from "infra/errors";
+import { InternalServerError, MethodNotAllowedError } from "infra/errors";
 
-export default async function status(_, response) {
-  try {
-    const updatedAt = new Date().toISOString();
+const router = createRouter();
 
-    const versionResult = await query("SHOW server_version;");
-    const version = versionResult.rows[0].server_version;
+router.get(getHandler);
 
-    const maxConnectionsResult = await query("SHOW max_connections;");
-    const maxConnections = parseInt(
-      maxConnectionsResult.rows[0].max_connections,
-    );
+export default router.handler({
+  onNoMatch: onNoMatchHandler,
+  onError: onErrorHandler,
+});
 
-    const openedConnectionsResult = await query(
-      "SELECT COUNT(*)::INT FROM pg_stat_activity WHERE datname = $1;",
-      [process.env.POSTGRES_DB],
-    );
-    const openedConnections = openedConnectionsResult.rows[0].count;
+function onNoMatchHandler(request, response) {
+  const publicError = new MethodNotAllowedError();
 
-    response.status(200).json({
-      updated_at: updatedAt,
-      dependencies: {
-        database: {
-          version,
-          max_connections: maxConnections,
-          opened_connections: openedConnections,
-        },
+  response.status(publicError.statusCode).json(publicError);
+}
+
+function onErrorHandler(error, request, response) {
+  const publicError = new InternalServerError({ cause: error });
+
+  console.log("\nErro dentro do catch do controller:");
+  console.log(publicError);
+
+  response.status(500).json(publicError);
+}
+
+async function getHandler(_, response) {
+  const updatedAt = new Date().toISOString();
+
+  const versionResult = await query("SHOW server_version;");
+  const version = versionResult.rows[0].server_version;
+
+  const maxConnectionsResult = await query("SHOW max_connections;");
+  const maxConnections = parseInt(maxConnectionsResult.rows[0].max_connections);
+
+  const openedConnectionsResult = await query(
+    "SELECT COUNT(*)::INT FROM pg_stat_activity WHERE datname = $1;",
+    [process.env.POSTGRES_DB],
+  );
+  const openedConnections = openedConnectionsResult.rows[0].count;
+
+  response.status(200).json({
+    updated_at: updatedAt,
+    dependencies: {
+      database: {
+        version,
+        max_connections: maxConnections,
+        opened_connections: openedConnections,
       },
-    });
-  } catch (error) {
-    const publicError = new InternalServerError({ cause: error });
-
-    console.log("\nErro dentro do catch do controller:");
-    console.log(publicError);
-
-    response.status(500).json(publicError);
-  }
+    },
+  });
 }

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,30 +1,12 @@
 import { createRouter } from "next-connect";
 import { query } from "infra/database";
-import { InternalServerError, MethodNotAllowedError } from "infra/errors";
+import controller from "infra/controller";
 
 const router = createRouter();
 
 router.get(getHandler);
 
-export default router.handler({
-  onNoMatch: onNoMatchHandler,
-  onError: onErrorHandler,
-});
-
-function onNoMatchHandler(request, response) {
-  const publicError = new MethodNotAllowedError();
-
-  response.status(publicError.statusCode).json(publicError);
-}
-
-function onErrorHandler(error, request, response) {
-  const publicError = new InternalServerError({ cause: error });
-
-  console.log("\nErro dentro do catch do controller:");
-  console.log(publicError);
-
-  response.status(500).json(publicError);
-}
+export default router.handler(controller.options);
 
 async function getHandler(_, response) {
   const updatedAt = new Date().toISOString();

--- a/tests/integration/api/v1/status/post.test.js
+++ b/tests/integration/api/v1/status/post.test.js
@@ -1,0 +1,26 @@
+import { waitForAllServices } from "tests/orquestrator";
+
+beforeAll(async () => {
+  await waitForAllServices();
+});
+
+describe("POST /api/v1/status", () => {
+  describe("Anonymous user", () => {
+    test("Retrieving current system status", async () => {
+      const response = await fetch("http://localhost:3000/api/v1/status", {
+        method: "POST",
+      });
+      expect(response.status).toBe(405);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "MethodNotAllowedError",
+        message: "Método não permitido para este endpoint.",
+        action:
+          "Verifique se o método HTTP enviado é válido para este endpoint.",
+        status_code: 405,
+      });
+    });
+  });
+});


### PR DESCRIPTION
1. Padroniza os `Controllers` dos endpoints `/migrations` e `/status`.
2. Adiciona 2 novos erros customizados: `MethodNotAllowedError` e `ServiceError`.
3. Faz o `InternalServerError` aceitar injeção do `statusCode`.